### PR TITLE
Mapping for every Anthropic model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (1.0.1)
+    omniai-anthropic (1.0.2)
       event_stream_parser
       omniai
       zeitwerk
@@ -57,7 +57,7 @@ GEM
     parser (3.3.3.0)
       ast (~> 2.4.1)
       racc
-    public_suffix (5.0.5)
+    public_suffix (5.1.0)
     racc (1.8.0)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -103,7 +103,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.6.15)
+    zeitwerk (2.6.16)
 
 PLATFORMS
   aarch64-linux-gnu

--- a/lib/omniai/anthropic/chat.rb
+++ b/lib/omniai/anthropic/chat.rb
@@ -13,9 +13,15 @@ module OmniAI
     #   chat.completion([{ role: 'system', content: 'Tell me a joke.' }])
     class Chat < OmniAI::Chat
       module Model
-        HAIKU = 'claude-3-haiku-20240307'
-        SONNET = 'claude-3-sonnet-20240229'
-        OPUS = 'claude-3-opus-20240229'
+        CLAUDE_INSTANT_1_0 = 'claude-instant-1.2'
+        CLAUDE_2_0 = 'claude-2.0'
+        CLAUDE_2_1 = 'claude-2.1'
+        CLAUDE_3_OPUS_20240229 = 'claude-3-opus-20240229'
+        CLAUDE_3_HAIKU_20240307 = 'claude-3-haiku-20240307'
+        CLAUDE_3_SONET_20240307 = 'claude-3-haiku-20240307'
+        CLAUDE_OPUS = CLAUDE_3_OPUS_20240229
+        CLAUDE_HAIKU = CLAUDE_3_HAIKU_20240307
+        CLAUDE_SONET = CLAUDE_3_SONET_20240307
       end
 
       protected

--- a/lib/omniai/anthropic/client.rb
+++ b/lib/omniai/anthropic/client.rb
@@ -55,7 +55,7 @@ module OmniAI
       # @param stream [Proc, nil] optional
       #
       # @return [OmniAI::Chat::Completion]
-      def chat(messages, model: Chat::Model::HAIKU, temperature: nil, format: nil, stream: nil)
+      def chat(messages, model: Chat::Model::CLAUDE_HAIKU, temperature: nil, format: nil, stream: nil)
         Chat.process!(messages, model:, temperature:, format:, stream:, client: self)
       end
     end

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end

--- a/spec/omniai/anthropic/chat_spec.rb
+++ b/spec/omniai/anthropic/chat_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OmniAI::Anthropic::Chat do
   describe '#completion' do
     subject(:completion) { described_class.process!(prompt, client:, model:) }
 
-    let(:model) { OmniAI::Anthropic::Chat::Model::HAIKU }
+    let(:model) { OmniAI::Anthropic::Chat::Model::CLAUDE_HAIKU }
 
     context 'with a string prompt' do
       let(:prompt) { 'Tell me a joke!' }


### PR DESCRIPTION
The following models are now properly defined:

 - CLAUDE_INSTANT_1_0 = 'claude-instant-1.2'
 - CLAUDE_2_0 = 'claude-2.0'
 - CLAUDE_2_1 = 'claude-2.1'
 - CLAUDE_3_OPUS_20240229 = 'claude-3-opus-20240229'
 - CLAUDE_3_HAIKU_20240307 = 'claude-3-haiku-20240307'
 - CLAUDE_3_SONET_20240307 = 'claude-3-haiku-20240307'

For convenience the following aliases are defined:

 - CLAUDE_OPUS
 - CLAUDE_HAIKU
 - CLAUDE_SONET