### PR TITLE
Support the Prompt Builder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (1.5.0)
+    omniai-anthropic (1.6.0)
       event_stream_parser
       omniai
       zeitwerk
@@ -50,7 +50,7 @@ GEM
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    omniai (1.5.1)
+    omniai (1.6.0)
       event_stream_parser
       http
       zeitwerk
@@ -63,7 +63,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)
-    rexml (3.3.1)
+    rexml (3.3.2)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)

--- a/README.md
+++ b/README.md
@@ -44,21 +44,10 @@ completion.choice.message.content # 'Why did the chicken cross the road? To get 
 ```
 
 ```ruby
-completion = client.chat({
-  role: OmniAI::Chat::Role::USER,
-  content: 'Is it wise to jump off a bridge?'
-})
-completion.choice.message.content # 'No.'
-```
-
-```ruby
-completion = client.chat([
-  {
-    role: OmniAI::Chat::Role::SYSTEM,
-    content: 'You are a helpful assistant.'
-  },
-  'What is the capital of Canada?',
-])
+completion = client.chat do |prompt|
+  prompt.system('You are a helpful assistant.')
+  prompt.user('What is the capital of Canada?')
+end
 completion.choice.message.content # 'The capital of Canada is Ottawa.'
 ```
 
@@ -102,9 +91,9 @@ client.chat('Be poetic.', stream:)
 `format` takes an optional symbol (`:json`) and modifies requests to send additional system text requesting JSON:
 
 ```ruby
-completion = client.chat([
-  { role: OmniAI::Chat::Role::USER, content: 'What is the name of the drummer for the Beatles?' }
-], format: :json)
+completion = client.chat(format: :json) do |prompt|
+  prompt.system(OmniAI::Chat::JSON_PROMPT)
+  prompt.user('What is the name of the drummer for the Beatles?')
 JSON.parse(completion.choice.message.content) # { "name": "Ringo" }
 ```
 

--- a/lib/omniai/anthropic/chat/response/stream.rb
+++ b/lib/omniai/anthropic/chat/response/stream.rb
@@ -46,8 +46,8 @@ module OmniAI
 
             # Handler for Type::MESSAGE_STOP
             #
-            # @param data [Hash]
-            def message_stop(_)
+            # @param _data [Hash]
+            def message_stop(_data)
               @id = nil
               @model = nil
               @role = nil
@@ -62,8 +62,8 @@ module OmniAI
 
             # Handler for Type::CONTENT_BLOCK_STOP
             #
-            # @param data [Hash]
-            def content_block_stop(_)
+            # @param _data [Hash]
+            def content_block_stop(_data)
               @index = nil
             end
 

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = '1.5.0'
+    VERSION = '1.6.0'
   end
 end


### PR DESCRIPTION
Compatibility with features like tools and files / URLs introduces a number of complexities when not using a standardized API for prompts. This swaps to use a better API when building prompts

## Usage

**w/ a basic prompt**

```ruby
completion = client.chat('What is the capital of Japan?')
```

**w/ a complex prompt**

```ruby
completion = client.chat do |prompt|
  prompt.system 'You are a helpful assistant with an expertise in animals.'
  prompt.user do |message|
    message.text 'What animals are in the attached photos?'
    message.url('https://.../cat.jpeg', "image/jpeg")
    message.url('https://.../dog.jpeg', "image/jpeg")
    message.file('./hamster.jpeg', "image/jpeg")
  end
end
```