### PR TITLE
Fix Typo w/ Claude Sonnet Constant and Replace Default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (1.6.2)
+    omniai-anthropic (1.6.3)
       event_stream_parser
       omniai
       zeitwerk
@@ -50,7 +50,7 @@ GEM
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    omniai (1.6.2)
+    omniai (1.6.3)
       event_stream_parser
       http
       zeitwerk

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ completion.choice.message.content # 'The capital of Canada is Ottawa.'
 `model` takes an optional string (default is `claude-3-haiku-20240307`):
 
 ```ruby
-completion = client.chat('Provide code for fibonacci', model: OmniAI::Anthropic::Chat::Model::CLAUDE_SONET)
+completion = client.chat('Provide code for fibonacci', model: OmniAI::Anthropic::Chat::Model::CLAUDE_SONNET)
 completion.choice.message.content # 'def fibonacci(n)...end'
 ```
 

--- a/lib/omniai/anthropic/chat.rb
+++ b/lib/omniai/anthropic/chat.rb
@@ -18,14 +18,14 @@ module OmniAI
         CLAUDE_2_1 = 'claude-2.1'
         CLAUDE_3_OPUS_20240229 = 'claude-3-opus-20240229'
         CLAUDE_3_HAIKU_20240307 = 'claude-3-haiku-20240307'
-        CLAUDE_3_SONET_20240307 = 'claude-3-haiku-20240307'
-        CLAUDE_3_5_SONET_20240620 = 'claude-3-5-sonnet-20240620'
+        CLAUDE_3_SONNET_20240307 = 'claude-3-sonnet-20240307'
+        CLAUDE_3_5_SONNET_20240620 = 'claude-3-5-sonnet-20240620'
         CLAUDE_OPUS = CLAUDE_3_OPUS_20240229
         CLAUDE_HAIKU = CLAUDE_3_HAIKU_20240307
-        CLAUDE_SONET = CLAUDE_3_5_SONET_20240620
+        CLAUDE_SONNET = CLAUDE_3_5_SONNET_20240620
       end
 
-      DEFAULT_MODEL = Model::CLAUDE_HAIKU
+      DEFAULT_MODEL = Model::CLAUDE_SONNET
 
       # @param [Media]
       # @return [Hash]

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = '1.6.2'
+    VERSION = '1.6.3'
   end
 end


### PR DESCRIPTION
The constant had a missing `n` in the name (the name of the constant rather than the constant value). This also changes the default to Claude SONNET 3.5