### PR TITLE
Adjust Target Ruby Version from v3.3 to v3.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,6 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.3
 
 RSpec/SpecFilePathFormat:
   CustomTransform:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (1.8.2)
+    omniai-anthropic (1.9.0)
       event_stream_parser
       omniai
       zeitwerk
@@ -45,12 +45,12 @@ GEM
     http-cookie (1.0.7)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    json (2.7.4)
+    json (2.7.5)
     language_server-protocol (3.17.0.3)
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    omniai (1.8.4)
+    omniai (1.9.0)
       event_stream_parser
       http
       zeitwerk
@@ -68,12 +68,12 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.1)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
@@ -89,7 +89,7 @@ GEM
       rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.3)
+    rubocop-ast (1.33.0)
       parser (>= 3.3.1.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
@@ -100,7 +100,7 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
+    simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     unicode-display_width (2.6.0)
     webmock (3.24.0)

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = '1.8.2'
+    VERSION = '1.9.0'
   end
 end

--- a/omniai-anthropic.gemspec
+++ b/omniai-anthropic.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description = 'An implementation of OmniAI for Anthropic'
   spec.homepage = 'https://github.com/ksylvest/omniai-anthropic'
 
-  spec.required_ruby_version = '>= 3.3.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['changelog_uri'] = "#{spec.homepage}/releases"


### PR DESCRIPTION
No breaking changes between v3.2 and v3.3 exist for this.