### PR TITLE
Haiku 3.5 Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'logger'
 gem 'rake'
 gem 'rspec'
 gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (1.9.0)
+    omniai-anthropic (1.9.1)
       event_stream_parser
       omniai
       zeitwerk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
+    logger (1.6.1)
     omniai (1.9.0)
       event_stream_parser
       http
@@ -124,6 +125,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  logger
   omniai-anthropic!
   rake
   rspec

--- a/lib/omniai/anthropic/chat.rb
+++ b/lib/omniai/anthropic/chat.rb
@@ -18,17 +18,18 @@ module OmniAI
         CLAUDE_2_1 = 'claude-2.1'
 
         CLAUDE_3_HAIKU_20240307 = 'claude-3-haiku-20240307'
+        CLAUDE_3_5_HAIKU_20241022 = 'claude-3-5-haiku-20241022'
         CLAUDE_3_OPUS_20240229 = 'claude-3-opus-20240229'
         CLAUDE_3_SONNET_20240209 = 'claude-3-sonnet-20240229'
         CLAUDE_3_SONNET_20240307 = 'claude-3-sonnet-20240307'
         CLAUDE_3_5_SONNET_20240620 = 'claude-3-5-sonnet-20240620'
         CLAUDE_3_5_SONNET_20241022 = 'claude-3-5-sonnet-20241022'
 
-        CLAUDE_3_HAIKU_LATEST = CLAUDE_3_HAIKU_20240307
+        CLAUDE_3_5_HAIKU_LATEST = 'claude-3-5-haiku-latest'
         CLAUDE_3_OPUS_LATEST = 'claude-3-opus-latest'
         CLAUDE_3_5_SONNET_LATEST = 'claude-3-5-sonnet-latest'
 
-        CLAUDE_HAIKU = CLAUDE_3_HAIKU_LATEST
+        CLAUDE_HAIKU = CLAUDE_3_5_HAIKU_LATEST
         CLAUDE_OPUS = CLAUDE_3_OPUS_LATEST
         CLAUDE_SONNET = CLAUDE_3_5_SONNET_LATEST
       end

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = '1.9.0'
+    VERSION = '1.9.1'
   end
 end


### PR DESCRIPTION
This includes constants for using Haiku 3.5:

## For the latest 3.5 Haiku: 

`OmniAI::Anthropic::Chat::Model::CLAUDE_3_5_HAIKU_LATEST` (i.e. `claude-3-5-haiku-latest`).

## For a fixed 3.5 Haiku: 

`OmniAI::Anthropic::Chat::Model::CLAUDE_3_5_HAIKU_20241022` (i.e. `claude-3-5-haiku-20241022`).

## Callout

`OmniAI::Anthropic::Chat::Model::CLAUDE_HAIKU` now points to `claude-3-5-haiku-latest`.