### PR TITLE
Suppor sonnet 3.7 via constants

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (1.9.6)
+    omniai-anthropic (1.9.7)
       event_stream_parser
       omniai
       zeitwerk

--- a/lib/omniai/anthropic/chat.rb
+++ b/lib/omniai/anthropic/chat.rb
@@ -24,14 +24,16 @@ module OmniAI
         CLAUDE_3_SONNET_20240307 = "claude-3-sonnet-20240307"
         CLAUDE_3_5_SONNET_20240620 = "claude-3-5-sonnet-20240620"
         CLAUDE_3_5_SONNET_20241022 = "claude-3-5-sonnet-20241022"
+        CLAUDE_3_7_SONNET_20250219 = "claude-3-7-sonnet-20250219"
 
         CLAUDE_3_5_HAIKU_LATEST = "claude-3-5-haiku-latest"
         CLAUDE_3_OPUS_LATEST = "claude-3-opus-latest"
         CLAUDE_3_5_SONNET_LATEST = "claude-3-5-sonnet-latest"
+        CLAUDE_3_7_SONNET_LATEST = "claude-3-7-sonnet-latest"
 
         CLAUDE_HAIKU = CLAUDE_3_5_HAIKU_LATEST
         CLAUDE_OPUS = CLAUDE_3_OPUS_LATEST
-        CLAUDE_SONNET = CLAUDE_3_5_SONNET_LATEST
+        CLAUDE_SONNET = CLAUDE_3_7_SONNET_LATEST
       end
 
       DEFAULT_MODEL = Model::CLAUDE_SONNET

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = "1.9.6"
+    VERSION = "1.9.7"
   end
 end


### PR DESCRIPTION
1. `CLAUDE_3_7_SONNET_20250219`
2. `CLAUDE_3_7_SONNET_LATEST`

This also swaps the default `CLAUDE_SONNET` constant to `claude-3-7-sonnet-latest` (which swaps the default to `claude-3-7-sonnet-latest`)