### PR TITLE
Properly Lock Version of the Parent Library

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (1.9.7)
+    omniai-anthropic (1.9.8)
       event_stream_parser
-      omniai
+      omniai (~> 1.9)
       zeitwerk
 
 GEM

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = "1.9.7"
+    VERSION = "1.9.8"
   end
 end

--- a/omniai-anthropic.gemspec
+++ b/omniai-anthropic.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai"
+  spec.add_dependency "omniai", "~> 1.9"
   spec.add_dependency "zeitwerk"
 end


### PR DESCRIPTION
This ensures the 2.0 release does not break the 1.9 clients.