### PR TITLE
Use the `stream?` Helper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     omniai-anthropic (2.0.0)
       event_stream_parser
-      omniai (~> 2.0)
+      omniai (~> 2.2)
       zeitwerk
 
 GEM
@@ -52,7 +52,7 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
-    omniai (2.1.1)
+    omniai (2.2.0)
       event_stream_parser
       http
       logger

--- a/lib/omniai/anthropic/chat.rb
+++ b/lib/omniai/anthropic/chat.rb
@@ -70,7 +70,7 @@ module OmniAI
           model: @model,
           messages:,
           system:,
-          stream: @stream.nil? ? nil : !@stream.nil?,
+          stream: stream? || nil,
           temperature: @temperature,
           tools: tools_payload,
         }).compact

--- a/omniai-anthropic.gemspec
+++ b/omniai-anthropic.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai", "~> 2.0"
+  spec.add_dependency "omniai", "~> 2.2"
   spec.add_dependency "zeitwerk"
 end


### PR DESCRIPTION
This properly uses the `stream?` helper defined in the OmniAI core library for building the streaming / non-streaming payloads.