### PR TITLE
Support File + URL Serializer Use for Documents

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (2.2.0)
+    omniai-anthropic (2.4.0)
       event_stream_parser
-      omniai (~> 2.2)
+      omniai (~> 2.4)
       zeitwerk
 
 GEM
@@ -17,7 +17,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    diff-lcs (1.6.0)
+    diff-lcs (1.6.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
     event_stream_parser (1.0.0)
@@ -52,7 +52,7 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
-    omniai (2.3.1)
+    omniai (2.4.0)
       event_stream_parser
       http
       logger

--- a/examples/chat_with_document
+++ b/examples/chat_with_document
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "omniai/anthropic"
+
+client = OmniAI::Anthropic::Client.new
+
+client.chat(stream: $stdout) do |prompt|
+  prompt.user do |message|
+    message.url("https://vancouver.ca/files/cov/other-sectors-tourism.PDF", "application/pdf")
+    message.text("In Vancouver per the attached document how many jobs supported tourism in 2015 / 2016 / 2017?")
+  end
+end

--- a/lib/omniai/anthropic.rb
+++ b/lib/omniai/anthropic.rb
@@ -6,6 +6,7 @@ require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem
 loader.push_dir(__dir__, namespace: OmniAI)
+loader.inflector.inflect "url_serializer" => "URLSerializer"
 loader.setup
 
 module OmniAI

--- a/lib/omniai/anthropic/chat.rb
+++ b/lib/omniai/anthropic/chat.rb
@@ -42,8 +42,8 @@ module OmniAI
       CONTEXT = Context.build do |context|
         context.serializers[:tool] = ToolSerializer.method(:serialize)
 
-        context.serializers[:file] = MediaSerializer.method(:serialize)
-        context.serializers[:url] = MediaSerializer.method(:serialize)
+        context.serializers[:file] = FileSerializer.method(:serialize)
+        context.serializers[:url] = URLSerializer.method(:serialize)
 
         context.serializers[:choice] = ChoiceSerializer.method(:serialize)
         context.deserializers[:choice] = ChoiceSerializer.method(:deserialize)

--- a/lib/omniai/anthropic/chat/file_serializer.rb
+++ b/lib/omniai/anthropic/chat/file_serializer.rb
@@ -3,13 +3,13 @@
 module OmniAI
   module Anthropic
     class Chat
-      # Overrides media serialize / deserialize.
-      module MediaSerializer
+      # Overrides file serialize / deserialize.
+      module FileSerializer
         # @param media [OmniAI::Chat::Media]
         # @return [Hash]
         def self.serialize(media, *)
           {
-            type: media.kind, # i.e. 'image' / 'video' / 'audio' / ...
+            type: media.kind, # i.e. 'image' / 'video' / 'audio' / 'document' / ...
             source: {
               type: "base64",
               media_type: media.type, # i.e. 'image/jpeg' / 'video/ogg' / 'audio/mpeg' / ...

--- a/lib/omniai/anthropic/chat/stream.rb
+++ b/lib/omniai/anthropic/chat/stream.rb
@@ -144,7 +144,7 @@ module OmniAI
 
         # Handler for Type::CONTENT_BLOCK_STOP
         #
-        # @param _data [Hash]
+        # @param data [Hash]
         def content_block_stop(data)
           index = data["index"]
           content = @data["content"][index]

--- a/lib/omniai/anthropic/chat/url_serializer.rb
+++ b/lib/omniai/anthropic/chat/url_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module Anthropic
+    class Chat
+      # Overrides url serialize / deserialize.
+      module URLSerializer
+        # @param url [OmniAI::Chat::Media]
+        # @return [Hash]
+        def self.serialize(url, *)
+          {
+            type: url.kind, # i.e. 'image' / 'video' / 'audio' / 'document' / ...
+            source: {
+              type: "url",
+              url: url.uri,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/anthropic/computer.rb
+++ b/lib/omniai/anthropic/computer.rb
@@ -117,8 +117,6 @@ module OmniAI
         "stdout=#{stdout.inspect} stderr=#{stderr.inspect} status=#{status}"
       end
 
-      # @param cmd [String]
-      #
       # @return [String]
       def xdotool(...)
         shell("xdotool", ...)

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = "2.2.0"
+    VERSION = "2.4.0"
   end
 end

--- a/omniai-anthropic.gemspec
+++ b/omniai-anthropic.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai", "~> 2.2"
+  spec.add_dependency "omniai", "~> 2.4"
   spec.add_dependency "zeitwerk"
 end

--- a/spec/omniai/anthropic/chat_spec.rb
+++ b/spec/omniai/anthropic/chat_spec.rb
@@ -248,8 +248,6 @@ RSpec.describe OmniAI::Anthropic::Chat do
       end
 
       before do
-        stub_request(:get, "https://localhost/cat.jpg").to_return(body: "cat")
-        stub_request(:get, "https://localhost/dog.jpg").to_return(body: "dog")
         stub_request(:post, "https://api.anthropic.com/v1/messages")
           .with(body: OmniAI::Anthropic.config.chat_options.merge({
             messages: [
@@ -257,8 +255,8 @@ RSpec.describe OmniAI::Anthropic::Chat do
                 role: "user",
                 content: [
                   { type: "text", text: "What are these photos of?" },
-                  { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "Y2F0" } },
-                  { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "ZG9n" } },
+                  { type: "image", source: { type: "url", url: "https://localhost/cat.jpg" } },
+                  { type: "image", source: { type: "url", url: "https://localhost/dog.jpg" } },
                   { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "" } },
                 ],
               },


### PR DESCRIPTION
This supports the Anthropic PDFs via either URL or Base64 encoded content. For example:

```ruby
require "omniai/anthropic"

client = OmniAI::Anthropic::Client.new

client.chat(stream: $stdout) do |prompt|
  prompt.user do |message|
    message.url("https://vancouver.ca/files/cov/other-sectors-tourism.PDF", "application/pdf")
    message.text("In Vancouver per the attached document how many jobs supported tourism in 2015 / 2016 / 2017?")
  end
end
```