### PR TITLE
Support Non-String Tool-Call Results

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (2.4.1)
+    omniai-anthropic (2.5.0)
       event_stream_parser
-      omniai (~> 2.4)
+      omniai (~> 2.5)
       zeitwerk
 
 GEM
@@ -52,7 +52,7 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
-    omniai (2.4.1)
+    omniai (2.5.0)
       event_stream_parser
       http
       logger

--- a/examples/chat_with_prompt
+++ b/examples/chat_with_prompt
@@ -4,12 +4,12 @@
 require "bundler/setup"
 require "omniai/anthropic"
 
-CLIENT = OmniAI::Anthropic::Client.new
+client = OmniAI::Anthropic::Client.new
 
 puts "> [SYSTEM] Respond in both English and French."
 puts "> [USER] What is the fastest animal?"
 
-CLIENT.chat(stream: $stdout) do |prompt|
+client.chat(stream: $stdout) do |prompt|
   prompt.system "Respond in both English and French."
   prompt.user "What is the fastest animal?"
 end

--- a/examples/chat_with_text
+++ b/examples/chat_with_text
@@ -4,9 +4,9 @@
 require "bundler/setup"
 require "omniai/anthropic"
 
-CLIENT = OmniAI::Anthropic::Client.new
+client = OmniAI::Anthropic::Client.new
 
 puts "> [USER] Tell me a joke"
 
-response = CLIENT.chat("Tell me a joke")
+response = client.chat("Tell me a joke")
 puts response.text

--- a/examples/chat_with_tools
+++ b/examples/chat_with_tools
@@ -4,25 +4,58 @@
 require "bundler/setup"
 require "omniai/anthropic"
 
-CLIENT = OmniAI::Anthropic::Client.new
+client = OmniAI::Anthropic::Client.new
 
-TOOL = OmniAI::Tool.new(
-  proc { |location:, unit: "celsius"| "#{rand(20..50)}° #{unit} in #{location}" },
-  name: "Weather",
-  description: "Lookup the weather in a location",
-  parameters: OmniAI::Tool::Parameters.new(
-    properties: {
-      location: OmniAI::Tool::Property.string(description: "e.g. Toronto"),
-      unit: OmniAI::Tool::Property.string(enum: %w[celcius farenheit]),
-    },
-    required: %i[location]
-  )
-)
+# @example
+#   tool = GeocodeTool.new
+#   tool.execute(location: "Toronto")
+class GeocodeTool < OmniAI::Tool
+  parameter :location, :string, description: "A location to find the weather for (e.g. 'Madrid, Spain')."
+  required %i[location]
+
+  # @param location [String]
+  #
+  # @return [Hash]
+  def execute(location:)
+    puts "[geocode] location=#{location}"
+
+    {
+      lat: rand(-90.0..90.0),
+      lng: rand(-180.0..180.0),
+    }
+  end
+end
+
+# @example
+#   tool = WeatherTool.new
+#   tool.execute(location: "Toronto", unit: "celsius")
+class WeatherTool < OmniAI::Tool
+  parameter :lat, :number, description: "The latitude of the location."
+  parameter :lng, :number, description: "The longitude of the location."
+  parameter :unit, :string, enum: %w[Celsius Fahrenheit], description: "The unit of measurement."
+  required %i[loction]
+
+  # @param lat [Float]
+  # @param lng [Float]
+  # @param unit [String] celsius or fahrenheit
+  #
+  # @return [String]
+  def execute(lat:, lng:, unit: "celsius")
+    puts "[weather] lat=#{lat} lng=#{lng} unit=#{unit}"
+
+    "#{rand(20..50)}° #{unit} at lat=#{lat} lng=#{lng}"
+  end
+end
 
 puts "> [SYSTEM] You are an expert in weather."
 puts "> [USER] What is the weather in 'London' in celsius and 'Madrid' in fahrenheit?"
 
-CLIENT.chat(stream: $stdout, tools: [TOOL]) do |prompt|
+tools = [
+  GeocodeTool.new,
+  WeatherTool.new,
+]
+
+client.chat(stream: $stdout, tools:) do |prompt|
   prompt.system "You are an expert in weather."
   prompt.user 'What is the weather in "London" in celsius and "Madrid" in fahrenheit?'
 end

--- a/examples/chat_with_vision
+++ b/examples/chat_with_vision
@@ -4,12 +4,12 @@
 require "bundler/setup"
 require "omniai/anthropic"
 
-CLIENT = OmniAI::Anthropic::Client.new
-
 CAT_URL = "https://images.unsplash.com/photo-1472491235688-bdc81a63246e?q=80&w=1024&h=1024&fit=crop&fm=jpg"
 DOG_URL = "https://images.unsplash.com/photo-1517849845537-4d257902454a?q=80&w=1024&h=1024&fit=crop&fm=jpg"
 
-CLIENT.chat(stream: $stdout) do |prompt|
+client = OmniAI::Anthropic::Client.new
+
+client.chat(stream: $stdout) do |prompt|
   prompt.system("You are a helpful biologist with an expertise in animals that responds with the latin names.")
   prompt.user do |message|
     message.text("What animals are in the attached photos?")

--- a/lib/omniai/anthropic/chat/tool_call_result_serializer.rb
+++ b/lib/omniai/anthropic/chat/tool_call_result_serializer.rb
@@ -6,16 +6,18 @@ module OmniAI
       # Overrides tool-call response serialize / deserialize.
       module ToolCallResultSerializer
         # @param tool_call_result [OmniAI::Chat::ToolCallResult]
+        #
         # @return [Hash]
         def self.serialize(tool_call_result, *)
           {
             type: "tool_result",
             tool_use_id: tool_call_result.tool_call_id,
-            content: tool_call_result.content,
+            content: tool_call_result.text,
           }
         end
 
         # @param data [Hash]
+        #
         # @return [OmniAI::Chat::ToolCallResult]
         def self.deserialize(data, *)
           tool_call_id = data["tool_use_id"]

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = "2.4.1"
+    VERSION = "2.5.0"
   end
 end

--- a/omniai-anthropic.gemspec
+++ b/omniai-anthropic.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai", "~> 2.4"
+  spec.add_dependency "omniai", "~> 2.5"
   spec.add_dependency "zeitwerk"
 end


### PR DESCRIPTION
This fixes the Anthropic library to properly convert any non-text tool-call-results to JSON. For example - given the following tool:

```ruby
# @example
#   tool = GeocodeTool.new
#   tool.execute(location: "Toronto")
class GeocodeTool < OmniAI::Tool
  parameter :location, :string, description: "A location to find the weather for (e.g. 'Madrid, Spain')."
  required %i[location]

  # @param location [String]
  #
  # @return [Hash]
  def execute(location:)
    puts "[geocode] location=#{location}"

    {
      lat: rand(-90.0..90.0),
      lng: rand(-180.0..180.0),
    }
  end
end
```

The LLM is provided back with the following text as a result:

```json
{
  "lat": 0.0,
  "lng": 0.0,
}
```