### PR TITLE
Compatibility w/ OmniAI v2.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (2.5.0)
+    omniai-anthropic (2.6.0)
       event_stream_parser
-      omniai (~> 2.5)
+      omniai (~> 2.6)
       zeitwerk
 
 GEM
@@ -52,7 +52,7 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
-    omniai (2.5.0)
+    omniai (2.6.0)
       event_stream_parser
       http
       logger
@@ -62,7 +62,7 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -75,13 +75,13 @@ GEM
       rspec-mocks (~> 3.13.0)
     rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.3)
+    rspec-expectations (3.13.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.2)
+    rspec-mocks (3.13.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.2)
+    rspec-support (3.13.3)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.75.5)

--- a/lib/omniai/anthropic/chat/tool_serializer.rb
+++ b/lib/omniai/anthropic/chat/tool_serializer.rb
@@ -11,7 +11,7 @@ module OmniAI
           {
             name: tool.name,
             description: tool.description,
-            input_schema: tool.parameters.is_a?(Tool::Parameters) ? tool.parameters.serialize : tool.parameters,
+            input_schema: tool.parameters.is_a?(OmniAI::Schema::Object) ? tool.parameters.serialize : tool.parameters,
           }.compact
         end
       end

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = "2.5.0"
+    VERSION = "2.6.0"
   end
 end

--- a/omniai-anthropic.gemspec
+++ b/omniai-anthropic.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai", "~> 2.5"
+  spec.add_dependency "omniai", "~> 2.6"
   spec.add_dependency "zeitwerk"
 end

--- a/spec/omniai/anthropic/chat/tool_serializer_spec.rb
+++ b/spec/omniai/anthropic/chat/tool_serializer_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe OmniAI::Anthropic::Chat::ToolSerializer do
         -> { "..." },
         name: "weather",
         description: "Finds the current weather",
-        parameters: OmniAI::Tool::Parameters.new(
+        parameters: OmniAI::Schema.object(
           properties: {
-            location: OmniAI::Tool::Property.string,
+            location: OmniAI::Schema.string,
           },
           required: ["location"]
         )


### PR DESCRIPTION
This fixes an issue w/ tool call usage using v2.6. Unfortunately Anthropic does not support the core feature of 2.6 (response schemas).