### PR TITLE
Add Claude Sonnet 5; float CLAUDE_SONNET to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.4.0
+
+### Added
+
+- `OmniAI::Anthropic::Chat::Model::CLAUDE_SONNET_5` (`"claude-sonnet-5"`).
+
+### Changed
+
+- The generic `CLAUDE_SONNET` alias now points to `CLAUDE_SONNET_5` (was `CLAUDE_SONNET_4_6`). Since `DEFAULT_MODEL` follows `CLAUDE_SONNET`, the provider default is now `claude-sonnet-5`. Pin `CLAUDE_SONNET_4_6` explicitly to keep the previous model.
+
 ## 3.3.0
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (3.3.0)
+    omniai-anthropic (3.4.0)
       event_stream_parser
       omniai (~> 3.7)
       openssl

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ completion.text # 'The capital of Canada is Ottawa.'
 
 #### Model
 
-`model` takes an optional string (default is `claude-sonnet-4-6`):
+`model` takes an optional string (default is `claude-sonnet-5`):
 
 ```ruby
 completion = client.chat('Provide code for fibonacci', model: OmniAI::Anthropic::Chat::Model::CLAUDE_SONNET)

--- a/lib/omniai/anthropic/chat.rb
+++ b/lib/omniai/anthropic/chat.rb
@@ -49,10 +49,11 @@ module OmniAI
         CLAUDE_SONNET_4_0 = "claude-sonnet-4-0"
         CLAUDE_SONNET_4_5 = "claude-sonnet-4-5"
         CLAUDE_SONNET_4_6 = "claude-sonnet-4-6"
+        CLAUDE_SONNET_5 = "claude-sonnet-5"
 
         CLAUDE_HAIKU = CLAUDE_HAIKU_4_5
         CLAUDE_OPUS = CLAUDE_OPUS_4_7
-        CLAUDE_SONNET = CLAUDE_SONNET_4_6
+        CLAUDE_SONNET = CLAUDE_SONNET_5
       end
 
       DEFAULT_MODEL = Model::CLAUDE_SONNET

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = "3.3.0"
+    VERSION = "3.4.0"
   end
 end


### PR DESCRIPTION
## Summary

Sonnet 5 was released. This adds the model to the Anthropic provider and floats the generic `CLAUDE_SONNET` tier alias forward to it (the same slot 4.6 currently occupies).

- Add `Model::CLAUDE_SONNET_5 = "claude-sonnet-5"`.
- Repoint `CLAUDE_SONNET = CLAUDE_SONNET_5` (was `CLAUDE_SONNET_4_6`). Because `DEFAULT_MODEL = Model::CLAUDE_SONNET`, the provider default also becomes `claude-sonnet-5`.
- `CLAUDE_SONNET_4_6` (and all other pinned constants) remain available — pinning is unaffected.
- README default updated `claude-sonnet-4-6` → `claude-sonnet-5`; CHANGELOG entry added; version bumped 3.3.0 → 3.4.0.

Model ID confirmed against the Anthropic model catalog: Sonnet 5 ships as the bare alias `claude-sonnet-5` (no dated snapshot, no `4-x`-style minor).

## Verification

Loaded the gem and resolved the constants live:

```
CLAUDE_SONNET_5   = claude-sonnet-5
CLAUDE_SONNET     = claude-sonnet-5    # generic alias
DEFAULT_MODEL     = claude-sonnet-5    # follows CLAUDE_SONNET
CLAUDE_SONNET_4_6 = claude-sonnet-4-6  # still pinnable
```

## Note for reviewers

Sonnet 5 differs from 4.6 in API behavior: adaptive thinking is on by default when `thinking` is omitted (4.6 ran thinking-off), and non-default `temperature`/`top_p`/`top_k` now return 400. This PR only touches model IDs; no payload-construction changes. Worth a follow-up to confirm the default `temperature`/`thinking` path doesn't 400 against `claude-sonnet-5`.