### PR TITLE
Release 3.4.1: forward :display through adaptive thinking config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.4.1
+
+### Fixed
+
+- `thinking: { effort:, display: }` now forwards `display` onto the adaptive thinking object (`{ type: "adaptive", display: ... }`). Previously the adaptive branch returned a bare `{ type: "adaptive" }` and silently dropped `:display`, so callers could not opt into summarized thinking on models that default `display` to `"omitted"` (Sonnet 5, Opus 4.7+). `display` remains strictly opt-in: when omitted, no `display` key is sent and the model's own default applies.
+
+  Known limitation: `:display` is only honored on the adaptive branch (reached by passing the `:effort` key). Passing `display` without `effort` falls through to enabled mode and is out of scope for this fix.
+
 ## 3.4.0
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (3.4.0)
+    omniai-anthropic (3.4.1)
       event_stream_parser
       omniai (~> 3.7)
       openssl

--- a/lib/omniai/anthropic/chat.rb
+++ b/lib/omniai/anthropic/chat.rb
@@ -116,6 +116,10 @@ module OmniAI
       # Example: `thinking: { budget_tokens: 10000 }` becomes `{ type: "enabled", budget_tokens: 10000 }`
       # Example: `thinking: { effort: nil }` becomes `{ type: "adaptive" }` (Claude decides)
       # Example: `thinking: { effort: "medium" }` becomes `{ type: "adaptive" }` + output_config
+      # Example: `thinking: { effort: "medium", display: "summarized" }` forwards display onto the adaptive object.
+      #
+      # NOTE: `display` is strictly opt-in pass-through. When omitted, no `display` key is sent and the
+      # model's own default applies (e.g. "omitted" on Sonnet 5 / Opus 4.7+, "summarized" on Sonnet 4.6).
       # @return [Hash, nil]
       def thinking_config
         return @thinking_config if defined?(@thinking_config)
@@ -126,7 +130,7 @@ module OmniAI
                            when true then { type: "enabled", budget_tokens: 10_000 }
                            when Hash
                              if thinking.key?(:effort)
-                               { type: "adaptive" }
+                               { type: "adaptive" }.merge(thinking.slice(:display))
                              else
                                { type: "enabled" }.merge(thinking)
                              end

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = "3.4.0"
+    VERSION = "3.4.1"
   end
 end

--- a/spec/omniai/anthropic/chat_spec.rb
+++ b/spec/omniai/anthropic/chat_spec.rb
@@ -404,6 +404,36 @@ RSpec.describe OmniAI::Anthropic::Chat do
       it { expect(completion.text).to eql("Two elephants fall off a cliff. Boom! Boom!") }
     end
 
+    context 'with thinking: { effort: "medium", display: "summarized" } option' do
+      subject(:completion) do
+        described_class.process!(prompt, client:, model:, thinking: { effort: "medium", display: "summarized" })
+      end
+
+      let(:prompt) { "Tell me a joke!" }
+
+      before do
+        stub_request(:post, "https://api.anthropic.com/v1/messages")
+          .with(body: OmniAI::Anthropic.config.chat_options.merge({
+            messages: [
+              { role: "user", content: [{ type: "text", text: "Tell me a joke!" }] },
+            ],
+            model:,
+            thinking: { type: "adaptive", display: "summarized" },
+            max_tokens: 32_768,
+            output_config: { effort: "medium" },
+          }))
+          .to_return_json(body: {
+            type: "message",
+            role: "assistant",
+            model:,
+            content: [{ type: "text", text: "Two elephants fall off a cliff. Boom! Boom!" }],
+            usage: { input_tokens: 32, output_tokens: 64 },
+          })
+      end
+
+      it { expect(completion.text).to eql("Two elephants fall off a cliff. Boom! Boom!") }
+    end
+
     context 'with thinking: { effort: "low" } option' do
       subject(:completion) { described_class.process!(prompt, client:, model:, thinking: { effort: "low" }) }
 


### PR DESCRIPTION
## Why this exists

The 3.4.1 fix (#195) never reached `main`. #195 was stacked with base `add-claude-sonnet-5` (the #194 feature branch), so merging it landed the commit on that branch — not `main`. The released 3.4.0 gem and `main` therefore have **no** `:display` forward, and the (now-deleted) phantom `v3.4.1` tag pointed at 3.4.0 code.

This branch is based directly on `main` and cherry-picks the single display-fix commit so it integrates cleanly. Supersedes #195.

## Change (unchanged from #195)

`thinking_config` adaptive branch:
```ruby
{ type: "adaptive" }.merge(thinking.slice(:display))
```
Strictly opt-in / no gem-side default — absent `:display` sends no key and the model default applies. Only honored on the adaptive branch (reached via `:effort`); `display` without `effort` is a documented out-of-scope limitation.

Sonnet 5 (and Opus 4.7+) default `thinking.display` to `"omitted"` (empty thinking text); 4.6 defaulted to `"summarized"`. After 3.4.0 floated `CLAUDE_SONNET` to `claude-sonnet-5`, callers had no way to opt back into summaries. This restores it.

## Verification

Live `Chat#payload[:thinking]` (not just WebMock):
```
with display: {type: "adaptive", display: "summarized"}
no display:   {type: "adaptive"}
```
- `rspec spec/omniai/anthropic/chat_spec.rb` → **19 examples, 0 failures**
- `rubocop` on touched files → no offenses
- version 3.4.0 → 3.4.1, CHANGELOG `## 3.4.1`, Gemfile.lock → 3.4.1

## Release steps after merge

1. Merge this PR (**base is `main`** — no stacking, so it actually lands).
2. `git checkout main && git pull`
3. `rake release` → tags `v3.4.1` at the real commit and pushes the gem to rubygems.

(The bad `v3.4.1` tag + GitHub release were already deleted; `rake release` will recreate the tag correctly.)