### PR TITLE
Add Claude Opus 5 + Fable 5; float CLAUDE_OPUS to Opus 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.5.0
+
+### Added
+
+- `OmniAI::Anthropic::Chat::Model::CLAUDE_OPUS_5` (`"claude-opus-5"`).
+- `OmniAI::Anthropic::Chat::Model::CLAUDE_FABLE_5` (`"claude-fable-5"`).
+
+### Changed
+
+- The generic `CLAUDE_OPUS` alias now points to `CLAUDE_OPUS_5` (was `CLAUDE_OPUS_4_7`). `DEFAULT_MODEL` follows `CLAUDE_SONNET`, not `CLAUDE_OPUS`, so the provider default is unchanged (`claude-sonnet-5`); this only affects callers passing `Model::CLAUDE_OPUS` explicitly. Pin `CLAUDE_OPUS_4_7` to keep the previous model.
+
 ## 3.4.1
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (3.4.1)
+    omniai-anthropic (3.5.0)
       event_stream_parser
       omniai (~> 3.7)
       openssl

--- a/lib/omniai/anthropic/chat.rb
+++ b/lib/omniai/anthropic/chat.rb
@@ -46,13 +46,15 @@ module OmniAI
         CLAUDE_OPUS_4_5 = "claude-opus-4-5"
         CLAUDE_OPUS_4_6 = "claude-opus-4-6"
         CLAUDE_OPUS_4_7 = "claude-opus-4-7"
+        CLAUDE_OPUS_5 = "claude-opus-5"
         CLAUDE_SONNET_4_0 = "claude-sonnet-4-0"
         CLAUDE_SONNET_4_5 = "claude-sonnet-4-5"
         CLAUDE_SONNET_4_6 = "claude-sonnet-4-6"
         CLAUDE_SONNET_5 = "claude-sonnet-5"
+        CLAUDE_FABLE_5 = "claude-fable-5"
 
         CLAUDE_HAIKU = CLAUDE_HAIKU_4_5
-        CLAUDE_OPUS = CLAUDE_OPUS_4_7
+        CLAUDE_OPUS = CLAUDE_OPUS_5
         CLAUDE_SONNET = CLAUDE_SONNET_5
       end
 

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = "3.4.1"
+    VERSION = "3.5.0"
   end
 end


### PR DESCRIPTION
## Summary

Adds the two Claude models missing from the gem, and floats the generic Opus alias.

- `CLAUDE_OPUS_5` = `"claude-opus-5"` — Anthropic's current recommended default for agentic coding
- `CLAUDE_FABLE_5` = `"claude-fable-5"` — the most capable widely-released model

Opus 4.8 is deliberately **not** included (explicit scope call). That leaves an intentional gap between `CLAUDE_OPUS_4_7` and `CLAUDE_OPUS_5`; these constants are a curated menu, not a mirror of Anthropic's catalog.

## Behavior change

`CLAUDE_OPUS` now points at `CLAUDE_OPUS_5` (was `CLAUDE_OPUS_4_7`), skipping two generations.

Blast radius is narrower than the equivalent change in omniai-google: `DEFAULT_MODEL` follows `CLAUDE_SONNET`, **not** `CLAUDE_OPUS`, so the provider default stays `claude-sonnet-5`. Only callers passing `Model::CLAUDE_OPUS` explicitly are affected. Pin `CLAUDE_OPUS_4_7` to keep the old behavior.

## Version

3.4.1 → **3.5.0** (minor: new models + alias change), matching the 3.4.0 precedent for adding Sonnet 5 and floating `CLAUDE_SONNET`. CHANGELOG entry included.

## Testing

- `bundle exec rspec` — 94 examples, 0 failures
- `bundle exec rubocop lib spec` — 35 files, no offenses

### Live verification — partial ⚠️

| Constant | Model ID | Live result |
|---|---|---|
| `CLAUDE_OPUS_5` | `claude-opus-5` | ✅ OK — response `model` echoes `"claude-opus-5"` |
| `CLAUDE_SONNET_5` (control) | `claude-sonnet-5` | ✅ OK — echoes `"claude-sonnet-5"` |
| `CLAUDE_FABLE_5` | `claude-fable-5` | ❌ **404 `not_found_error`** |

`claude-fable-5` could not be verified. `GET /v1/models` returns 9 models for this key and `claude-fable-5` is not among them (`claude-opus-5` is). The control passing rules out a harness fault.

The id matches Anthropic's published GA id for Fable 5, so this reads as a **missing org entitlement rather than a wrong string** — but it is unverified, and reviewers should treat it as such. Happy to drop `CLAUDE_FABLE_5` into a follow-up PR if you'd rather every constant here be live-verified.

## Out of scope (noted, not changed)

`GET /v1/models` lists `claude-opus-4-6` and `claude-sonnet-4-6` with **no dated variants**, which supports the earlier suspicion that the existing `CLAUDE_OPUS_4_6_20260217` / `CLAUDE_SONNET_4_6_20260217` constants are invalid ids. Removing them is a breaking change for anyone who pinned them, so it belongs in its own PR.