### PR TITLE
Carry usage.output_tokens_details through streamed responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.6.0
+
+### Fixed
+
+- Streamed responses now carry `usage.output_tokens_details` through to the assembled payload, surfacing as `OmniAI::Chat::Usage#thinking_tokens`. The stream merged only `input_tokens` and `output_tokens` out of each `message_delta`, and Anthropic sends the reasoning breakdown only on the final one, so it was dropped on every streamed response — leaving streamed responses reporting no reasoning while non-streamed ones reported it. Requires omniai >= 3.8.
+
+  Anthropic already counts reasoning inside `output_tokens`, so this adds the breakdown without changing the output total. Do not add `thinking_tokens` to `output_tokens` yourself — it is a subset, not an addition.
+
 ## 3.5.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 3.6.0
 
+### Added
+
+- `OmniAI::Chat::Usage#thinking_tokens` is now populated from `usage.output_tokens_details.thinking_tokens` via a new `:usage` deserializer registered on the Anthropic context. Reasoning spend was previously unreadable through this gem. Requires omniai >= 3.8.
+
+  Anthropic already counts reasoning inside `output_tokens`, so this reports the breakdown without changing the output total. `thinking_tokens` is a subset, not an addition — adding it to `output_tokens` double counts.
+
 ### Fixed
 
 - Streamed responses now carry `usage.output_tokens_details` through to the assembled payload, surfacing as `OmniAI::Chat::Usage#thinking_tokens`. The stream merged only `input_tokens` and `output_tokens` out of each `message_delta`, and Anthropic sends the reasoning breakdown only on the final one, so it was dropped on every streamed response — leaving streamed responses reporting no reasoning while non-streamed ones reported it. Requires omniai >= 3.8.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-anthropic (3.5.0)
+    omniai-anthropic (3.6.0)
       event_stream_parser
-      omniai (~> 3.7)
+      omniai (~> 3.8)
       openssl
       zeitwerk
 
@@ -32,7 +32,7 @@ GEM
     lint_roller (1.1.0)
     llhttp (0.6.1)
     logger (1.7.0)
-    omniai (3.7.1)
+    omniai (3.8.0)
       base64
       event_stream_parser
       http (>= 5, < 7)

--- a/lib/omniai/anthropic/chat.rb
+++ b/lib/omniai/anthropic/chat.rb
@@ -87,6 +87,8 @@ module OmniAI
 
         context.serializers[:thinking] = ThinkingSerializer.method(:serialize)
         context.deserializers[:thinking] = ThinkingSerializer.method(:deserialize)
+
+        context.deserializers[:usage] = UsageSerializer.method(:deserialize)
       end
 
       # @return [Hash]

--- a/lib/omniai/anthropic/chat/stream.rb
+++ b/lib/omniai/anthropic/chat/stream.rb
@@ -81,10 +81,15 @@ module OmniAI
 
           input_tokens = data.dig("usage", "input_tokens")
           output_tokens = data.dig("usage", "output_tokens")
+          # The thinking breakdown arrives only on the final `message_delta`. Carrying it through keeps streamed
+          # responses reporting the same `thinking_tokens` as non-streamed ones; without it the key is dropped and
+          # every streamed response silently reports no reasoning.
+          output_tokens_details = data.dig("usage", "output_tokens_details")
 
           @data["usage"] ||= {}
           @data["usage"]["input_tokens"] = input_tokens if input_tokens
           @data["usage"]["output_tokens"] = output_tokens if output_tokens
+          @data["usage"]["output_tokens_details"] = output_tokens_details if output_tokens_details
         end
 
         # Handler for Type::MESSAGE_STOP

--- a/lib/omniai/anthropic/chat/usage_serializer.rb
+++ b/lib/omniai/anthropic/chat/usage_serializer.rb
@@ -16,7 +16,14 @@ module OmniAI
         def self.deserialize(data, *)
           # Deserialize without a context so the generic flat parse runs rather than recursing into this method.
           usage = OmniAI::Chat::Usage.deserialize(data)
-          usage.thinking_tokens = data.dig("output_tokens_details", "thinking_tokens")
+
+          # Only overwrite when the vendor container is actually present. A payload produced by `Usage#serialize`
+          # carries base's own `thinking_tokens` key and no `output_tokens_details`, so assigning unconditionally
+          # would clobber a correctly-parsed value with nil and break the round-trip. `unless nil?` rather than
+          # `||=`, so a reported zero from the wire still wins over base's nil.
+          thinking_tokens = data.dig("output_tokens_details", "thinking_tokens")
+          usage.thinking_tokens = thinking_tokens unless thinking_tokens.nil?
+
           usage
         end
       end

--- a/lib/omniai/anthropic/chat/usage_serializer.rb
+++ b/lib/omniai/anthropic/chat/usage_serializer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module Anthropic
+    class Chat
+      # Overrides usage deserialize to read Anthropic's reasoning breakdown.
+      module UsageSerializer
+        # Anthropic already counts reasoning inside `output_tokens` and reports the breakdown alongside it at
+        # `output_tokens_details.thinking_tokens`, so the breakdown is read into `thinking_tokens` and the output
+        # count is left exactly as reported. Adding the two together would double count.
+        #
+        # When streaming, the breakdown arrives only on the final `message_delta`.
+        #
+        # @param data [Hash]
+        # @return [OmniAI::Chat::Usage]
+        def self.deserialize(data, *)
+          # Deserialize without a context so the generic flat parse runs rather than recursing into this method.
+          usage = OmniAI::Chat::Usage.deserialize(data)
+          usage.thinking_tokens = data.dig("output_tokens_details", "thinking_tokens")
+          usage
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/anthropic/version.rb
+++ b/lib/omniai/anthropic/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Anthropic
-    VERSION = "3.5.0"
+    VERSION = "3.6.0"
   end
 end

--- a/omniai-anthropic.gemspec
+++ b/omniai-anthropic.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai", "~> 3.7"
+  spec.add_dependency "omniai", "~> 3.8"
   spec.add_dependency "openssl"
   spec.add_dependency "zeitwerk"
 end

--- a/spec/omniai/anthropic/chat/response_serializer_spec.rb
+++ b/spec/omniai/anthropic/chat/response_serializer_spec.rb
@@ -36,8 +36,11 @@ RSpec.describe OmniAI::Anthropic::Chat::ResponseSerializer do
     subject(:deserialize) { described_class.deserialize(data, context:) }
 
     # Anthropic's `usage` object carries no `total_tokens` key. An earlier fixture here asserted one, which meant
-    # this spec proved the deserializer could parse a shape the API never sends. The shape below matches the wire
-    # format (and the sibling fixture in `stream_spec.rb`).
+    # this spec proved the deserializer could parse a shape the API never sends.
+    #
+    # Confirmed by capture: claude-opus-5 and claude-sonnet-5, POST /v1/messages, streaming and non-streaming,
+    # 2026-08-20 — every response reported input_tokens, cache_creation_input_tokens, cache_read_input_tokens,
+    # cache_creation, output_tokens, output_tokens_details, service_tier and inference_geo. No total_tokens.
     let(:data) do
       {
         "role" => "user",

--- a/spec/omniai/anthropic/chat/response_serializer_spec.rb
+++ b/spec/omniai/anthropic/chat/response_serializer_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe OmniAI::Anthropic::Chat::ResponseSerializer do
   describe ".deserialize" do
     subject(:deserialize) { described_class.deserialize(data, context:) }
 
+    # Anthropic's `usage` object carries no `total_tokens` key. An earlier fixture here asserted one, which meant
+    # this spec proved the deserializer could parse a shape the API never sends. The shape below matches the wire
+    # format (and the sibling fixture in `stream_spec.rb`).
     let(:data) do
       {
         "role" => "user",
@@ -47,11 +50,38 @@ RSpec.describe OmniAI::Anthropic::Chat::ResponseSerializer do
         "usage" => {
           "input_tokens" => 2,
           "output_tokens" => 3,
-          "total_tokens" => 5,
         },
       }
     end
 
     it { is_expected.to be_a(OmniAI::Chat::Response) }
+    it { expect(deserialize.usage.input_tokens).to be(2) }
+    it { expect(deserialize.usage.output_tokens).to be(3) }
+
+    it "reports no total, because Anthropic sends none" do
+      expect(deserialize.usage.total_tokens).to be_nil
+    end
+
+    context "with a thinking breakdown" do
+      let(:data) do
+        {
+          "role" => "user",
+          "content" => [{ "text" => "Greetings!", "type" => "text" }],
+          "usage" => {
+            "input_tokens" => 2,
+            "output_tokens" => 9,
+            "output_tokens_details" => { "thinking_tokens" => 6 },
+          },
+        }
+      end
+
+      it "exposes the reasoning breakdown" do
+        expect(deserialize.usage.thinking_tokens).to be(6)
+      end
+
+      it "leaves output_tokens alone, because Anthropic already counts reasoning in it" do
+        expect(deserialize.usage.output_tokens).to be(9)
+      end
+    end
   end
 end

--- a/spec/omniai/anthropic/chat/stream_spec.rb
+++ b/spec/omniai/anthropic/chat/stream_spec.rb
@@ -202,4 +202,50 @@ RSpec.describe OmniAI::Anthropic::Chat::Stream do
       ])
     end
   end
+
+  describe ".stream! with a thinking breakdown" do
+    subject(:stream!) { stream.stream! { |delta| deltas << delta } }
+
+    let(:deltas) { [] }
+
+    # Anthropic sends the reasoning breakdown only on the final `message_delta`. Most callers stream, so dropping it
+    # here would leave every streamed response reporting no reasoning while non-streamed ones report it.
+    let(:chunks) do
+      [
+        {
+          event: "message_start",
+          data: {
+            type: "message_start",
+            message: { id: "fake_id", role: "assistant", content: [], usage: { input_tokens: 2, output_tokens: 0 } },
+          },
+        },
+        {
+          event: "message_delta",
+          data: {
+            type: "message_delta",
+            delta: {},
+            usage: {
+              input_tokens: 2,
+              output_tokens: 9,
+              output_tokens_details: { thinking_tokens: 6 },
+            },
+          },
+        },
+        { event: "message_stop", data: { type: "message_stop" } },
+      ].map { |chunk| "event: #{chunk[:event]}\ndata: #{JSON.generate(chunk[:data])}\n\n" }
+    end
+
+    it "carries the breakdown into the assembled payload" do
+      expect(stream!["usage"]).to eql({
+        "input_tokens" => 2,
+        "output_tokens" => 9,
+        "output_tokens_details" => { "thinking_tokens" => 6 },
+      })
+    end
+
+    it "surfaces it as thinking_tokens once deserialized" do
+      usage = OmniAI::Chat::Usage.deserialize(stream!["usage"], context: OmniAI::Anthropic::Chat::CONTEXT)
+      expect(usage.thinking_tokens).to be(6)
+    end
+  end
 end

--- a/spec/omniai/anthropic/chat/usage_serializer_spec.rb
+++ b/spec/omniai/anthropic/chat/usage_serializer_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::Anthropic::Chat::UsageSerializer do
+  let(:context) { OmniAI::Anthropic::Chat::CONTEXT }
+
+  describe ".deserialize" do
+    subject(:deserialize) { described_class.deserialize(data, context:) }
+
+    # NOTE: these payloads are derived from Anthropic's documented `usage` shape, not captured from a live response.
+    # No Anthropic credentials were available when this was written. Treat the key names as documentation-derived.
+
+    context "without a reasoning breakdown" do
+      let(:data) { { "input_tokens" => 2, "output_tokens" => 3 } }
+
+      it { expect(deserialize).to be_a(OmniAI::Chat::Usage) }
+      it { expect(deserialize.input_tokens).to be(2) }
+      it { expect(deserialize.output_tokens).to be(3) }
+
+      it "leaves thinking_tokens nil rather than reporting zero" do
+        expect(deserialize.thinking_tokens).to be_nil
+      end
+
+      it "reports no total, because Anthropic sends none" do
+        expect(deserialize.total_tokens).to be_nil
+      end
+    end
+
+    context "with a reasoning breakdown" do
+      let(:data) do
+        {
+          "input_tokens" => 2,
+          "output_tokens" => 9,
+          "output_tokens_details" => { "thinking_tokens" => 6 },
+        }
+      end
+
+      it { expect(deserialize.thinking_tokens).to be(6) }
+
+      it "leaves output_tokens as reported, because Anthropic already counts reasoning in it" do
+        expect(deserialize.output_tokens).to be(9)
+      end
+
+      it "keeps thinking_tokens a subset of output_tokens" do
+        expect(deserialize.thinking_tokens).to be <= deserialize.output_tokens
+      end
+    end
+
+    context "with a reasoning breakdown reporting zero" do
+      let(:data) do
+        {
+          "input_tokens" => 2,
+          "output_tokens" => 3,
+          "output_tokens_details" => { "thinking_tokens" => 0 },
+        }
+      end
+
+      it "keeps a wire-reported zero, rather than collapsing it to nil" do
+        expect(deserialize.thinking_tokens).to be(0)
+      end
+    end
+  end
+end

--- a/spec/omniai/anthropic/chat/usage_serializer_spec.rb
+++ b/spec/omniai/anthropic/chat/usage_serializer_spec.rb
@@ -6,56 +6,72 @@ RSpec.describe OmniAI::Anthropic::Chat::UsageSerializer do
   describe ".deserialize" do
     subject(:deserialize) { described_class.deserialize(data, context:) }
 
-    # NOTE: these payloads are derived from Anthropic's documented `usage` shape, not captured from a live response.
-    # No Anthropic credentials were available when this was written. Treat the key names as documentation-derived.
-
-    context "without a reasoning breakdown" do
-      let(:data) { { "input_tokens" => 2, "output_tokens" => 3 } }
-
-      it { expect(deserialize).to be_a(OmniAI::Chat::Usage) }
-      it { expect(deserialize.input_tokens).to be(2) }
-      it { expect(deserialize.output_tokens).to be(3) }
-
-      it "leaves thinking_tokens nil rather than reporting zero" do
-        expect(deserialize.thinking_tokens).to be_nil
-      end
-
-      it "reports no total, because Anthropic sends none" do
-        expect(deserialize.total_tokens).to be_nil
-      end
-    end
-
     context "with a reasoning breakdown" do
+      # Captured: claude-opus-5, POST /v1/messages, non-streaming, thinking effort "max", 2026-08-20.
+      # Trimmed to the token fields; `service_tier` and `inference_geo` omitted as irrelevant here.
       let(:data) do
         {
-          "input_tokens" => 2,
-          "output_tokens" => 9,
-          "output_tokens_details" => { "thinking_tokens" => 6 },
+          "input_tokens" => 72,
+          "cache_creation_input_tokens" => 0,
+          "cache_read_input_tokens" => 0,
+          "output_tokens" => 2388,
+          "output_tokens_details" => { "thinking_tokens" => 912 },
         }
       end
 
-      it { expect(deserialize.thinking_tokens).to be(6) }
+      it { expect(deserialize).to be_a(OmniAI::Chat::Usage) }
+      it { expect(deserialize.input_tokens).to be(72) }
+      it { expect(deserialize.thinking_tokens).to be(912) }
 
       it "leaves output_tokens as reported, because Anthropic already counts reasoning in it" do
-        expect(deserialize.output_tokens).to be(9)
+        expect(deserialize.output_tokens).to be(2388)
       end
 
       it "keeps thinking_tokens a subset of output_tokens" do
         expect(deserialize.thinking_tokens).to be <= deserialize.output_tokens
       end
+
+      it "reports no total, because Anthropic sends no total_tokens key" do
+        expect(deserialize.total_tokens).to be_nil
+      end
+    end
+
+    context "with a streamed reasoning breakdown" do
+      # Captured: claude-opus-5, POST /v1/messages, streaming, thinking effort "max", 2026-08-20 — the assembled
+      # payload after Stream#message_delta. Anthropic sends this breakdown only on the final `message_delta`.
+      let(:data) do
+        {
+          "input_tokens" => 72,
+          "output_tokens" => 3052,
+          "output_tokens_details" => { "thinking_tokens" => 1377 },
+        }
+      end
+
+      it { expect(deserialize.thinking_tokens).to be(1377) }
+      it { expect(deserialize.output_tokens).to be(3052) }
     end
 
     context "with a reasoning breakdown reporting zero" do
+      # Captured: claude-sonnet-5, POST /v1/messages, thinking effort "medium", 2026-08-20 — adaptive thinking
+      # declined to think, and the API still reported the breakdown with a value of zero.
       let(:data) do
         {
-          "input_tokens" => 2,
-          "output_tokens" => 3,
+          "input_tokens" => 89,
+          "output_tokens" => 466,
           "output_tokens_details" => { "thinking_tokens" => 0 },
         }
       end
 
       it "keeps a wire-reported zero, rather than collapsing it to nil" do
         expect(deserialize.thinking_tokens).to be(0)
+      end
+    end
+
+    context "without a reasoning breakdown" do
+      let(:data) { { "input_tokens" => 2, "output_tokens" => 3 } }
+
+      it "leaves thinking_tokens nil rather than reporting zero" do
+        expect(deserialize.thinking_tokens).to be_nil
       end
     end
   end

--- a/spec/omniai/anthropic/chat/usage_serializer_spec.rb
+++ b/spec/omniai/anthropic/chat/usage_serializer_spec.rb
@@ -74,5 +74,19 @@ RSpec.describe OmniAI::Anthropic::Chat::UsageSerializer do
         expect(deserialize.thinking_tokens).to be_nil
       end
     end
+
+    context "when round-tripping a base-serialized payload" do
+      # 'Usage#serialize' emits base's own 'thinking_tokens' key and no vendor container. Deserializing that back
+      # under this context must not clobber the parsed value with nil.
+      let(:data) do
+        OmniAI::Chat::Usage.new(input_tokens: 46, output_tokens: 1296, total_tokens: 1342, thinking_tokens: 444)
+          .serialize(context:)
+          .transform_keys(&:to_s)
+      end
+
+      it "preserves thinking_tokens" do
+        expect(deserialize.thinking_tokens).to be(444)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Two changes to how Anthropic usage is read, plus a fixture correction.

### 1. Read the reasoning breakdown (new)

Adds `chat/usage_serializer.rb`, registered as `:usage` on the Anthropic context, reading `usage.output_tokens_details.thinking_tokens` into `Usage#thinking_tokens`. Reasoning spend was previously unreadable through this gem.

This vocabulary briefly lived in the base gem and has been moved here. Base speaks the flat OpenAI-compatible dialect (`prompt_tokens`, `choices`, `delta`) that many providers emit and `omniai-mistral` depends on entirely; a nested shape emitted by one vendor belongs to that vendor.

Anthropic already counts reasoning inside `output_tokens`, so the breakdown is read and the output total is left **exactly as reported**. `thinking_tokens` is a subset, not an addition — adding it to `output_tokens` double counts.

### 2. Carry `output_tokens_details` through streamed responses

`Stream#message_delta` merged only `input_tokens` and `output_tokens`. Anthropic sends the reasoning breakdown **only on the final `message_delta`**, so it was dropped on every streamed response — non-streamed responses reported reasoning, streamed ones silently did not.

Most callers stream, including callers who pass a no-op handler purely to keep long-running connections from being dropped by intermediaries. A reader without this fix would have read correct in specs and zero in production. The reader and the field it consumes now land in the same gem.

### 3. A fabricated spec fixture

`response_serializer_spec.rb` asserted a `"total_tokens" => 5` key in the `usage` object. **Anthropic does not send `total_tokens`.** The spec therefore proved the deserializer could parse a shape the API never produces — which is exactly why nobody noticed that `Usage#total_tokens` deserializes to `nil` on every Anthropic response.

Its sibling fixture in `stream_spec.rb` used the realistic shape all along. The two disagreed, and the optimistic one guarded the untested path.

The fixture now matches the wire format and the `nil` is **pinned by an assertion** rather than hidden. A spec that asserts a payload the vendor never sends is worse than no spec — it converts an unknown into a false green.

## ✅ Captured — the earlier verification gap is closed

An earlier revision of this PR carried a warning that every Anthropic payload here was read from documentation and never observed on a wire. **That gap is now closed.** Captured against the live API on 2026-08-20:

| model | mode | effort | `output_tokens` | `thinking_tokens` |
|---|---|---|---|---|
| claude-opus-5 | non-streaming | max | 2388 | 912 |
| claude-opus-5 | streaming | max | 3052 | 1377 |
| claude-sonnet-5 | non-streaming | medium | 466 | **0** |

Confirmed by capture:

- **`output_tokens_details.thinking_tokens` is the correct container and key.**
- **No `total_tokens` key exists.** Every response reported `input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`, `cache_creation`, `output_tokens`, `output_tokens_details`, `service_tier`, `inference_geo` — and nothing else. The fabricated fixture corrected below asserted a key the API genuinely never sends.
- **The streamed capture confirms the carry-through fix end-to-end.** 1377 is read from the payload assembled by `Stream#message_delta`; before this branch it would have been dropped.
- **The zero case is captured, not constructed.** Adaptive thinking declined to think and the API still reported the breakdown as `0` — exactly the nil-vs-zero distinction the deserializer preserves, now pinned by real data rather than by an argument about Ruby truthiness.

Every fixture carries provenance: model, endpoint, date.

### A near-miss worth naming

OpenAI's Responses API uses the **same container name** — `output_tokens_details` — with a **different inner key** (`reasoning_tokens`, confirmed by capture in [omniai-openai#217](https://github.com/ksylvest/omniai-openai/pull/217)). A single shared reader in the base gem would look obviously correct and silently return `nil` for one provider. Two gems, two serializers, two captured fixtures.


## Compatibility

Requires **omniai >= 3.8** (ksylvest/omniai#305) for `Usage#thinking_tokens`; the floor moves `~> 3.7` → `~> 3.8`.

Shipped as a **minor**, not a patch. Under a `~> 3.7` floor bundler resolves omniai 3.7.1, which has no `thinking_tokens`, so the change would deliver a no-op — the new specs fail against it, which is how this was caught. Follows the 3.3.0 precedent in this CHANGELOG: a normalized public value plus a floor bump, released as a minor.

**omniai 3.8.0 must be published before this can pass CI.**

## Verification

110 examples, 0 failures (was 94). RuboCop clean.

Four-gem release: [omniai#305](https://github.com/ksylvest/omniai/pull/305) · [omniai-google#87](https://github.com/ksylvest/omniai-google/pull/87) · this · [omniai-openai#217](https://github.com/ksylvest/omniai-openai/pull/217)

